### PR TITLE
Implement Reactive Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,36 @@ npm install rxui --save
 ### TypeScript (Recommended)
 
 ```
-import {ReactiveObject} from "rxui/ReactiveObject";
-import {ISearchService} from "wherever/search/service/is";
+import {ReactiveObject} from "rxui/reactive-object";
+import {ReactiveCommand} from "rxui/reactive-command";
+import {Observable} from "rxjs/Observable";
 
-class SearchViewModel extends ReactiveObject {
-    public get searchQuery(): string {
-        return this.get("searchQuery");   
-    }
+// Example from ReactiveUI Documentation (http://docs.reactiveui.net/en/user-guide/commands/an-example.html)
+class LoginViewModel extends ReactiveObject {
     
-    public set searchQuery(value: string): void {
-        this.set("searchQuery", value);
-    }
+    public loginCommand: ReactiveCommand<boolean>;
+    public resetCommand: ReactiveCommand<boolean>;
     
-    constructor(private searchService: ISearchService) {
-        var canSearch = this.whenAny("searchQuery", q => q.newPropertyValue != "");
+    constructor() {
+        var canLogin = this.whenAnyValue<string, string, boolean>(
+            "userName",
+            "password",
+            (userName, password) => userName && password
+        );
         
-        // TODO:
+        this.loginCommand = ReactiveCommand.createFromObservable(
+            (a) => this.loginAsync(),
+            canLogin
+        );
+        
+        this.resetCommand = ReactiveCommand.create(() => {
+            this.set("userName", "");
+            this.set("password", "");
+        });
+    }
+    
+    loginAsync(): Observable<boolean> {
+        // Cool login logic   
     }
 }
 ```

--- a/src/operator/invoke-command.ts
+++ b/src/operator/invoke-command.ts
@@ -1,0 +1,39 @@
+import {Observable} from "rxjs/Observable";
+import {ReactiveObject} from "../reactive-object";
+import {ReactiveCommand} from "../reactive-command";
+
+/**
+ * Creates a new cold observable that maps values observed from the source Observable to values resolved from a ReactiveCommand.
+ * Essentially, this means that the command is executed whenever the source Observable resolves a new value, so long as the command is executable at the moment.
+ * @param source The Observable that should be used as the trigger for the command.
+ * @param obj The Reactive Object that the command exists on.
+ * @param command The name of the property that holds the ReactiveCommand that should be subscribed to. 
+ *                Alternatively, the actual command object that should be executed can be passed in. 
+ */
+export function invokeCommand<TObj extends ReactiveObject, TResult>(source: Observable<any>, obj: TObj, command: string | ReactiveCommand<TResult>): Observable<TResult> {
+    var commandObservable: Observable<ReactiveCommand<TResult>>;
+    var canExecute: Observable<boolean>;
+    var isExecuting: Observable<boolean>;
+    if (typeof command === "string") {
+        // Make sure that the current command is observed
+        commandObservable = obj.whenSingle(command, true).map(e => e.newPropertyValue);
+        canExecute = commandObservable.map(c => c.canExecute).switch<boolean>();
+    } else {
+        commandObservable = Observable.of(command);
+        canExecute = command.canExecute;
+    }
+    var results = source
+        .withLatestFrom(commandObservable, canExecute, (v1, command, canExecute) => {
+            return {
+                canExecute,
+                command,
+                observedValue: v1
+            };
+        })
+        .filter(o => o.canExecute && o.command != null)
+        .distinctUntilChanged()
+        .map(o => {
+            return o.command.executeAsync(o.observedValue);
+        }).merge();
+    return results;
+}

--- a/src/reactive-command.ts
+++ b/src/reactive-command.ts
@@ -1,0 +1,77 @@
+import {Observable} from "rxjs/Observable";
+import {Subject} from "rxjs/Subject";
+
+/**
+ * Defines a class that represents a command that can run operations in the background.
+ */
+export class ReactiveCommand<TResult> {
+
+    private subject: Subject<TResult>;
+    private executing: Subject<boolean>;
+    private _canExecute: Observable<boolean>;
+    private _isExecuting: Observable<boolean>;
+
+    /**
+     * Gets an observable that represents whether the command is currently executing.
+     */
+    public get isExecuting(): Observable<boolean> {
+        return this._isExecuting;
+    }
+    
+    /**
+     * Gets an observable that represents whether this command can execute.
+     */
+    public get canExecute(): Observable<boolean> {
+        return this._canExecute;
+    }
+
+    /**
+     * Creates a new Reactive Command.
+     * @param canRun An observable that determines whether the given task is allowed to run at a given moment.
+     * @param task A function that returns an observable that represents the asynchronous operation.
+     */
+    constructor(private canRun: Observable<boolean>, private task: (args) => Observable<TResult>) {
+        this.subject = new Subject<TResult>();
+        this.executing = new Subject<boolean>();
+        this._isExecuting = this.executing.startWith(false).distinctUntilChanged();
+        this._canExecute = this.canRun
+            .startWith(false)
+            .combineLatest(this._isExecuting, (canRun, isExecuting) => {
+                return canRun && !isExecuting;
+            })
+            .distinctUntilChanged()
+            .repeat(1);
+    }
+
+    /**
+     * Creates a new Reactive Command that can run the given task when executed.
+     */
+    public static createAsyncTask<TResult>(canRun: Observable<boolean>, task: (args) => Promise<TResult>): ReactiveCommand<TResult> {
+        return new ReactiveCommand(canRun, (args) => Observable.fromPromise(task(args)));
+    }
+
+    /**
+     * Executes this command.
+     */
+    public execute(arg): Observable<TResult> {
+        this.executing.next(true);
+        var observable = this.task(arg);
+        var subscriber = observable.subscribe(result => {
+            this.subject.next(result);
+        }, err => {
+            this.subject.error(err);
+            this.executing.next(false);
+        }, () => {
+            subscriber.unsubscribe();
+            this.executing.next(false);
+        });
+        return observable;
+    }
+
+    /**
+     * Gets the observable that represents the result of this command's operations.
+     */
+    public get observable(): Observable<TResult> {
+        return this.subject;
+    }
+}

--- a/src/reactive-command.ts
+++ b/src/reactive-command.ts
@@ -65,9 +65,27 @@ export class ReactiveCommand<TResult> {
     }
 
     /**
+     * Creates a new Reactive Command that can run the given synchronous task when executed.
+     * @param task A function that executes some synchronous task and returns an optional value.
+     * @param canRun An Observable whose stream of values determine whether the command is allowed to run at a certain time.
+     * @param scheduler The scheduler that all of the results from the task should be observed on.
+     */
+    public static create<TResult>(task: (args) => (TResult | void), canRun?: Observable<boolean>, scheduler?: Scheduler): ReactiveCommand<TResult> {
+        return new ReactiveCommand((args) => {
+            var result = task(args);
+            if(typeof result !== "undefined") {
+                return Observable.of(result);
+            } else {
+                // TODO: replace with Unit
+                return Observable.of(null);
+            }
+        }, ReactiveCommand.defaultCanRun(canRun), ReactiveCommand.defaultScheduler(scheduler));
+    }
+
+    /**
      * Creates a new Reactive Command that can run the given task when executed.
      * @param task A function that returns a promise that completes when the task has finished executing.
-     * @param canRun An observable that resolves whenever the command is allowed to run.
+     * @param canRun An Observable whose stream of values determine whether the command is allowed to run at a certain time.
      * @param scheduler The scheduler that all of the results from the task should be observed on.
      */
     public static createFromTask<TResult>(task: (args) => Promise<TResult>, canRun?: Observable<boolean>, scheduler?: Scheduler): ReactiveCommand<TResult> {
@@ -77,7 +95,7 @@ export class ReactiveCommand<TResult> {
     /**
      * Creates a new Reactive Command that can run the given task when executed.
      * @param task A function that returns an observable that completes when the task has finished executing.
-     * @param canRun An observable that resolves whenever the command is allowed to run.
+     * @param canRun An Observable whose stream of values determine whether the command is allowed to run at a certain time.
      * @param scheduler The scheduler that all of the results from the task should be observed on.
      */
     public static createFromObservable<TResult>(task: (args) => Observable<TResult>, canRun?: Observable<boolean>, scheduler?: Scheduler): ReactiveCommand<TResult> {

--- a/src/reactive-command.ts
+++ b/src/reactive-command.ts
@@ -86,6 +86,8 @@ export class ReactiveCommand<TResult> {
 
     /**
      * Executes this command asynchronously.
+     * Note that this method does not check whether the command is currently executable.
+     * Use ReactiveObject methods such as invokeCommand
      */
     public executeAsync(arg: any = null): Observable<TResult> {
         this.executing.next(true);

--- a/src/reactive-command.ts
+++ b/src/reactive-command.ts
@@ -105,7 +105,7 @@ export class ReactiveCommand<TResult> {
     /**
      * Executes this command asynchronously.
      * Note that this method does not check whether the command is currently executable.
-     * Use ReactiveObject methods such as invokeCommand
+     * Use ReactiveObject methods such as `invokeCommandWhen()` to take advantage of canExecute. 
      */
     public executeAsync(arg: any = null): Observable<TResult> {
         this.executing.next(true);

--- a/src/reactive-command.ts
+++ b/src/reactive-command.ts
@@ -17,7 +17,7 @@ export class ReactiveCommand<TResult> {
     public get isExecuting(): Observable<boolean> {
         return this._isExecuting;
     }
-    
+
     /**
      * Gets an observable that represents whether this command can execute.
      */
@@ -39,8 +39,7 @@ export class ReactiveCommand<TResult> {
             .combineLatest(this._isExecuting, (canRun, isExecuting) => {
                 return canRun && !isExecuting;
             })
-            .distinctUntilChanged()
-            .repeat(1);
+            .distinctUntilChanged();
     }
 
     /**
@@ -51,18 +50,17 @@ export class ReactiveCommand<TResult> {
     }
 
     /**
-     * Executes this command.
+     * Executes this command asynchronously.
      */
-    public execute(arg): Observable<TResult> {
+    public executeAsync(arg: any = null): Observable<TResult> {
         this.executing.next(true);
         var observable = this.task(arg);
-        var subscriber = observable.subscribe(result => {
+        observable.subscribe(result => {
             this.subject.next(result);
         }, err => {
             this.subject.error(err);
             this.executing.next(false);
         }, () => {
-            subscriber.unsubscribe();
             this.executing.next(false);
         });
         return observable;

--- a/src/reactive-object.ts
+++ b/src/reactive-object.ts
@@ -63,7 +63,6 @@ export class ReactiveObject {
         if (children.length === 1) {
             var child: ReactiveObject = this;
             var observable = child.propertyChanged.filter(e => {
-                console.log(e.propertyName + ":" + prop);
                 return e.propertyName == prop;
             });
             if (emitCurrentVal) {
@@ -76,7 +75,6 @@ export class ReactiveObject {
             var firstProp = children[0]; // = "first"
             // All of the other properties = "second.third"
             var propertiesWithoutFirst = prop.substring(firstProp.length + 1);
-            console.log("Properties without first: " + propertiesWithoutFirst);
             // Get the object/value that is at the "first" key of this object.
             var firstChild: ReactiveObject = this.get(firstProp);
             if (typeof firstChild.whenSingle === "function") {

--- a/src/reactive-object.ts
+++ b/src/reactive-object.ts
@@ -99,18 +99,6 @@ export class ReactiveObject {
                 throw new Error(`Not all of the objects in the chain of properties are Reactive Objects. Specifically, the property '${firstProp}', is not a Reactive Object when it should be.`);
             }
         }
-
-
-        // child.child2.prop
-        // observe child
-        // observe child2
-        // observe prop (pipe)
-        // newChild
-        // observe newChild.child2
-        // observe prop (pipe)
-        // newChild2
-        // observe prop (pipe)
-
     }
 
     /**

--- a/src/reactive-observable.ts
+++ b/src/reactive-observable.ts
@@ -1,0 +1,17 @@
+import {Observable} from "rxjs/Observable";
+import {ReactiveObject} from "./reactive-object";
+import {ReactiveCommand} from "./reactive-command";
+import * as InvokeCommand from "./operator/invoke-command";
+
+/**
+ * Defines an interface that represents an observable that is able to invoke commands upon observation of a value. 
+ */
+export interface ReactiveObservable<T> extends Observable<T> {
+    /**
+    * Subscribes to an Observable and attempts to execute a command on the given reactive object when the subscribed observable emits a value.
+    * @param obj The Reactive Object that the command exists on.
+    * @param command The name of the property that holds the ReactiveCommand that should be subscribed to.
+    */
+    invokeCommand<TObj extends ReactiveObject, TResult>(obj: TObj, command: string): ReactiveObservable<TResult>;
+}
+

--- a/src/rx-app.ts
+++ b/src/rx-app.ts
@@ -13,4 +13,11 @@ export class RxApp {
         return Schedulers.queue;
     }
     
+    /**
+     * Gets a scheduler that executes work as soon as it is scheduled.
+     */
+    public static get immediateScheduler(): Scheduler {
+        return Schedulers.asap;
+    }
+    
 }

--- a/src/rx-app.ts
+++ b/src/rx-app.ts
@@ -1,0 +1,16 @@
+import {Scheduler} from "rxjs/Scheduler";
+import {Scheduler as Schedulers} from "rxjs/Rx";
+
+/**
+ * Defines a class that contains static properties that are useful for a Reactive Application.
+ */
+export class RxApp {
+    
+    /**
+     * Gets a scheduler that can be used to scheduler work on the main UI thread.
+     */
+    public static get mainThreadScheduler(): Scheduler {
+        return Schedulers.queue;
+    }
+    
+}

--- a/test/invoke-command-tests.ts
+++ b/test/invoke-command-tests.ts
@@ -27,7 +27,7 @@ describe("invokeCommand()", () => {
         expect(callCount).to.equal(0);
         
         obj.set("prop", "value");
-        expect(callCount).to.equal(1);   
+        expect(callCount).to.equal(1);
     });
     it("should call executeAsync() on the given command with the observed value as the argument", () => {
         var callCount = 0;

--- a/test/invoke-command-tests.ts
+++ b/test/invoke-command-tests.ts
@@ -1,0 +1,89 @@
+import {Observable} from "rxjs/Rx";
+import {ReactiveObject} from "../src/reactive-object";
+import {ReactiveCommand} from "../src/reactive-command";
+import {ReactiveObservable} from "../src/reactive-observable";
+import {PropertyChangedEventArgs} from "../src/events/property-changed-event-args";
+import {expect} from "chai";
+import {invokeCommand} from "../src/operator/invoke-command";
+import {RxApp} from "../src/rx-app";
+
+describe("invokeCommand()", () => {
+    it("should not call executeAsync() on the given command when the command is not executable", () => {
+        var callCount = 0;
+        
+        var obj = new ReactiveObject();
+        
+        var observable = obj.whenAnyValue<string>("prop");
+        
+        var command = ReactiveCommand.createFromObservable(a => {
+            callCount++;
+            return Observable.of(true);
+        }, observable.map(val => val === "value")); // only execute the command when "prop" has been changed to "value"
+        
+        obj.set("command", command);
+        obj.invokeCommandWhen(observable, command).subscribe();    
+        
+        obj.set("prop", "val");
+        expect(callCount).to.equal(0);
+        
+        obj.set("prop", "value");
+        expect(callCount).to.equal(1);   
+    });
+    it("should call executeAsync() on the given command with the observed value as the argument", () => {
+        var callCount = 0;
+        var callParams = [];
+        var command = ReactiveCommand.createFromObservable(a => {
+            callCount++;
+            callParams.push(a);
+            return Observable.of(true);
+        });
+        
+        var obj = new ReactiveObject();
+        
+        var observable = obj.whenAnyValue<string>("prop");
+        obj.invokeCommandWhen(observable, command).subscribe();    
+        
+        obj.set("prop", "value");
+        expect(callCount).to.equal(1);
+        expect(callParams[0]).to.equal("value");
+    });
+    
+    it("should not call executeAsync() on the current command when that command is not executable", () => {
+        var callCount = 0;
+        
+        var obj = new ReactiveObject();
+        
+        var command = ReactiveCommand.createFromObservable(a => {
+            callCount++;
+            return Observable.of(true);
+        }, obj.whenAnyValue("prop").map(val => val === "value")); // only execute the command when "prop" has been changed to "value"
+        
+        obj.set("command", command);
+        
+        obj.invokeCommandWhen(obj.whenAnyValue("prop"), "command").subscribe();    
+        
+        obj.set("prop", "val");
+        expect(callCount).to.equal(0);
+        
+        obj.set("prop", "value");
+        expect(callCount).to.equal(1);  
+    });
+    
+    it("should call executeAsync() on the current command with the observed value as the argument", () => {
+        var callCount = 0;
+        var callParams = [];
+        var command = ReactiveCommand.createFromObservable(a => {
+            callCount++;
+            callParams.push(a);
+            return Observable.of(true);
+        });
+        
+        var obj = new ReactiveObject();
+        obj.set("command", command);        
+        obj.invokeCommandWhen(obj.whenAnyValue<string>("prop"), "command").subscribe();    
+        
+        obj.set("prop", "value");
+        expect(callCount).to.equal(1);
+        expect(callParams[0]).to.equal("value");
+    });
+});

--- a/test/invoke-command-tests.ts
+++ b/test/invoke-command-tests.ts
@@ -13,15 +13,14 @@ describe("invokeCommand()", () => {
         
         var obj = new ReactiveObject();
         
-        var observable = obj.whenAnyValue<string>("prop");
-        
         var command = ReactiveCommand.createFromObservable(a => {
             callCount++;
             return Observable.of(true);
-        }, observable.map(val => val === "value")); // only execute the command when "prop" has been changed to "value"
+        }, obj.whenAnyValue<string>("prop").map(val => val === "value")); // only execute the command when "prop" has been changed to "value"
         
         obj.set("command", command);
-        obj.invokeCommandWhen(observable, command).subscribe();    
+        
+        obj.invokeCommandWhen(obj.whenAnyValue<string>("prop"), command).subscribe();    
         
         obj.set("prop", "val");
         expect(callCount).to.equal(0);
@@ -39,9 +38,7 @@ describe("invokeCommand()", () => {
         });
         
         var obj = new ReactiveObject();
-        
-        var observable = obj.whenAnyValue<string>("prop");
-        obj.invokeCommandWhen(observable, command).subscribe();    
+        obj.invokeCommandWhen(obj.whenAnyValue<string>("prop"), command).subscribe();    
         
         obj.set("prop", "value");
         expect(callCount).to.equal(1);

--- a/test/reactive-command-tests.ts
+++ b/test/reactive-command-tests.ts
@@ -1,12 +1,66 @@
 import {ReactiveCommand} from "../src/reactive-command";
+import {TestScheduler} from "rxjs/testing/TestScheduler";
 import {Observable} from "rxjs/Rx";
+import {expect} from "chai";
 
 describe("ReactiveCommand", () => {
     describe(".canExecute", () => {
-       it("should default to false", (done) => {
-           var command: ReactiveCommand<boolean> = new ReactiveCommand(Observable.empty(), (a) => Observable.fromArray([false]));
-           
-           
-       });
+        it("should default to false", (done) => {
+            var command: ReactiveCommand<boolean> = new ReactiveCommand(Observable.empty(), (a) => Observable.fromArray([true]));
+
+            command.canExecute.take(1).subscribe(can => {
+                expect(can).to.be.false;
+                done();
+            }, err => done(err));
+        });
+        it("should use what the given canRun observable observes", (done) => {
+            var command: ReactiveCommand<boolean> = new ReactiveCommand(Observable.fromArray([true]).delay(5), (a) => Observable.fromArray([false]));
+
+            command.canExecute.bufferTime(10).take(1).subscribe((can: boolean[]) => {
+                expect(can.length).to.equal(2);
+                expect(can[0]).to.be.false;
+                expect(can[1]).to.be.true;
+                done();
+            }, err => done(err));
+        });
+        it("should be false while the command is executing", (done) => {
+            var command: ReactiveCommand<boolean> = new ReactiveCommand(Observable.fromArray([true]), (a) => {
+                return Observable.fromArray([false]);
+            });
+
+            command.canExecute.bufferCount(3).take(1).subscribe((can: boolean[]) => {
+                expect(can.length).to.equal(3);
+                expect(can[0]).to.be.true;
+                expect(can[1]).to.be.false; // Cannot Execute While Running. 
+                expect(can[2]).to.be.true;
+                done();
+            }, err => done(err));
+
+            command.executeAsync(null);
+        });
+    });
+
+    describe(".isExecuting", () => {
+        it("should default to false", (done) => {
+            var command: ReactiveCommand<boolean> = new ReactiveCommand(Observable.empty(), (a) => Observable.fromArray([true]));
+
+            command.isExecuting.take(1).subscribe(executing => {
+                expect(executing).to.be.false;
+                done();
+            }, err => done(err));
+        });
+        it("should be true while the command is executing", (done) => {
+            var command: ReactiveCommand<boolean> = new ReactiveCommand(Observable.fromArray([true]), (a) => Observable.fromArray([true]));
+
+            command.isExecuting.bufferCount(3).take(1).subscribe((executing: boolean[]) => {
+                expect(executing.length).to.equal(3);
+                expect(executing[0]).to.be.false;
+                expect(executing[1]).to.be.true;
+                expect(executing[2]).to.be.false;
+                done();
+            });
+            
+            command.executeAsync(null);
+        });
     });
 });

--- a/test/reactive-command-tests.ts
+++ b/test/reactive-command-tests.ts
@@ -15,6 +15,28 @@ describe("ReactiveCommand", () => {
                 done();
             }, err => done(err));
         });
+        it("should return a command that resolves with errors from the promise", (done) => {
+            var command: ReactiveCommand<void> = ReactiveCommand.createFromTask((a) => {
+               return Promise.reject("Error"); 
+            });
+            
+            command.executeAsync().take(1).subscribe(null, err => {
+                expect(err).to.equal("Error");
+                done()
+            });
+        });
+        it("should return a command that resolves with errors from the task execution", (done) => {
+            var error = new Error("Error"); 
+            var task: any = (arg) => {
+                throw error;
+            };            
+            var command: ReactiveCommand<void> = ReactiveCommand.createFromTask<void>(task);
+            
+            command.executeAsync().take(1).subscribe(null, err => {
+                expect(err).to.equal(error);
+                done();
+            });
+        });
     });
     describe(".create()", () => {
        it("should return a command that resolves with returned values from the task", (done) => {

--- a/test/reactive-command-tests.ts
+++ b/test/reactive-command-tests.ts
@@ -4,7 +4,31 @@ import {Observable} from "rxjs/Rx";
 import {expect} from "chai";
 
 describe("ReactiveCommand", () => {
-    describe(".canExecute", () => {
+    describe(".createFromTask()", () => {
+        it("should return a command that resolves with values from the promise", (done) => {
+            var command: ReactiveCommand<boolean> = ReactiveCommand.createFromTask((a) => {
+                return Promise.resolve(true);
+            });
+            
+            command.executeAsync().take(1).subscribe(result => {
+                expect(result).to.be.true;
+                done();
+            }, err => done(err));
+        });
+    });
+    describe(".create()", () => {
+       it("should return a command that resolves with returned values from the task", (done) => {
+           var command: ReactiveCommand<string> = ReactiveCommand.create((a) => {
+              return "value"; 
+           });
+           
+           command.executeAsync().take(1).subscribe(result => {
+              expect(result).to.equal("value");
+              done(); 
+           }, err => done(err));
+       });
+    });
+    describe("#canExecute", () => {
         it("should default to false", (done) => {
             var command: ReactiveCommand<boolean> = ReactiveCommand.createFromObservable((a) => Observable.of(true), Observable.empty());
 
@@ -40,7 +64,7 @@ describe("ReactiveCommand", () => {
         });
     });
 
-    describe(".isExecuting", () => {
+    describe("#isExecuting", () => {
         it("should default to false", (done) => {
             var command: ReactiveCommand<boolean> = ReactiveCommand.createFromObservable((a) => Observable.of(true), Observable.empty());
 
@@ -64,7 +88,7 @@ describe("ReactiveCommand", () => {
         });
     });
 
-    describe(".executeAsync()", () => {
+    describe("#executeAsync()", () => {
         it("should run the configured task on the given scheduler", (done) => {
             var scheduler = new TestScheduler((actual, expected) => {
                 expect(actual).to.deep.equal(expected);

--- a/test/reactive-command-tests.ts
+++ b/test/reactive-command-tests.ts
@@ -1,0 +1,12 @@
+import {ReactiveCommand} from "../src/reactive-command";
+import {Observable} from "rxjs/Rx";
+
+describe("ReactiveCommand", () => {
+    describe(".canExecute", () => {
+       it("should default to false", (done) => {
+           var command: ReactiveCommand<boolean> = new ReactiveCommand(Observable.empty(), (a) => Observable.fromArray([false]));
+           
+           
+       });
+    });
+});

--- a/test/reactive-object-tests.ts
+++ b/test/reactive-object-tests.ts
@@ -5,7 +5,7 @@ import {PropertyChangedEventArgs} from "../src/events/property-changed-event-arg
 import {expect} from "chai";
 
 describe("ReactiveObject", () => {
-    describe(".set()", () => {
+    describe("#set()", () => {
         it("should change the value retrieved by .get()", () => {
             var obj: ReactiveObject = new ReactiveObject();
 
@@ -33,7 +33,7 @@ describe("ReactiveObject", () => {
         });
     });
 
-    describe(".get(prop)", () => {
+    describe("#get(prop)", () => {
         it("should return the value at obj[prop]", () => {
             var obj: ReactiveObject = new ReactiveObject();
             obj["prop"] = "value";
@@ -48,7 +48,7 @@ describe("ReactiveObject", () => {
         });
     });
 
-    describe(".emitPropertyChanged()", () => {
+    describe("#emitPropertyChanged()", () => {
         it("should emit new PropertyChangedEventArgs when called", (done) => {
             class MyReactiveObj extends ReactiveObject {
                 public triggerChangeEvent(): void {
@@ -87,7 +87,7 @@ describe("ReactiveObject", () => {
         });
     });
 
-    describe(".whenAny(prop)", () => {
+    describe("#whenAny(prop)", () => {
         it("should return an observable", () => {
             var obj: ReactiveObject = new ReactiveObject();
             var observable = obj.whenAny("prop");
@@ -189,7 +189,7 @@ describe("ReactiveObject", () => {
         });
     });
 
-    describe(".whenAny(prop1, prop2, prop3)", () => {
+    describe("#whenAny(prop1, prop2, prop3)", () => {
         it("should observe property changes for multiple children", (done) => {
             var obj: ReactiveObject = new ReactiveObject();
             obj.set("prop1", "prop1Value");
@@ -252,7 +252,7 @@ describe("ReactiveObject", () => {
         });
     });
 
-    describe(".whenAnyValue(prop)", () => {
+    describe("#whenAnyValue(prop)", () => {
         it("should return an observable", () => {
             var obj: ReactiveObject = new ReactiveObject();
             var observable = obj.whenAnyValue("prop");


### PR DESCRIPTION
Based on documentation from [ReactiveUI.ReactiveCommand](http://docs.reactiveui.net/en/user-guide/commands/an-example.html).

**This pull request is not complete yet**

There are a couple of issues that crop up with TypeScript/JavaScript when trying to port ReactiveUI. The most prevalent of which are LINQ and Extension Methods. [While it is possible](https://github.com/Reactive-Extensions/RxJS/blob/master/doc/gettingstarted/operators.md) to add custom methods to the Observable class, it feels sloppy, and does not have good TypeScript support. 

I've been thinking about a couple ways to combat these issues, and here I will document them.

First, for LINQ, it would be possible to create wrapper objects that utilize ES5 getters that can trigger when called and therefore create an expression-like graph. This way, we could replace strings with functions, and fool TypeScript's type system into thinking it is the same object, which would provide intellisense support.

```TypeScript
obj.whenAnyValue(vm => vm.prop.otherProp);

// The object passed into the above function would look like this:
var path = [];
var vm = {
  get prop() {
    path.push("prop");
    return {
      get otherProp() {
        path.push("otherProp");
        return {};
      }
    }
  }
};

// The implementation of whenAnyValue invokes the given function, and then
// evaluates the produced path to create the Observable.
```

For Extension Methods, the best option is probably to just rework the API so that it is still readable while not having extension methods. This way, we can also provide greater context around the execution of commands, and help enforce certain best practices, like always disposing of observables once they are no longer used.