### PR TITLE
Prevent false notifications when parents change

### DIFF
--- a/src/reactive-object.ts
+++ b/src/reactive-object.ts
@@ -524,7 +524,7 @@ export class ReactiveObject {
         }
         iterateProperties(map ? args.slice(0, args.length - 1) : args);
         var observableList = finalProperties.map(prop => {
-            return this.whenSingle(prop, true);
+            return this.whenSingle(prop, true).distinctUntilChanged((x, y) => x.newPropertyValue === y.newPropertyValue);
         }).filter(o => o != null);
         if (map) {
             return Observable.combineLatest<TResult>(...observableList, map);


### PR DESCRIPTION
Adds distinctUntilChanged so that if parents change, but values remain unchanged, there won't be false change notifications.
e.g:

```
   this.something = { somethingElse: 1 };
   this.whenAnyValue((x) => x.something.somethingElse);
   this.something = { somethingElse: 1 }; // this should not send another change notification
```

I don't know if there are other occasions, or if this is the best location for the change - awaiting feedback :)

This puts the behavior inline with C#'s ReactiveUI:
- https://github.com/reactiveui/ReactiveUI/issues/657
- https://github.com/reactiveui/ReactiveUI/blob/b418df64918da0c78a378af1b846afbab0f4e5ae/src/ReactiveUI/ReactiveNotifyPropertyChangedMixin.cs#L123
- https://github.com/reactiveui/ReactiveUI/blob/b418df64918da0c78a378af1b846afbab0f4e5ae/src/ReactiveUI/ObservableAsPropertyHelper.cs#L98